### PR TITLE
Moves jsdom and i18nliner to be dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "test": "grunt test && mocha tmp/test"
   },
   "peerDependencies": {
-    "handlebars": ">=1.3 <3"
+    "handlebars": ">=1.3 <3",
+    "i18nliner": "~0.1.0"
   },
   "dependencies": {
-    "jsdom": "~0.8.10",
-    "i18nliner": "~0.1.0"
+    "jsdom": "~0.8.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "test": "grunt test && mocha tmp/test"
   },
   "peerDependencies": {
-    "handlebars": ">=1.3 <3",
-    "i18nliner": "~0.1.0",
-    "jsdom": "~0.8.10"
+    "handlebars": ">=1.3 <3"
+  },
+  "dependencies": {
+    "jsdom": "~0.8.10",
+    "i18nliner": "~0.1.0"
   }
 }


### PR DESCRIPTION
This makes it so the package is ready to be used after npm v3 lands.