### PR TITLE
reimplement noncommutative sort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 before_script: 'npm install -g grunt-cli'
 language: node_js
 node_js:
-  - "6"
-  - "5"
-  - "4"
+  - "10"
+  - "12"

--- a/lib/pre_processor.js
+++ b/lib/pre_processor.js
@@ -88,22 +88,6 @@ function concatNode(string, tempMap) {
   return new SexprNode(parts);
 }
 
-function sortBy(array, fn) {
-  return array.map(function(item, i) {
-    return [fn(item), i, item];
-  }).sort(function(left, right) {
-    var leftSort = left[0]
-      , rightSort = right[0];
-    if (leftSort !== rightSort) {
-      if (leftSort > rightSort) return 1;
-      if (leftSort < rightSort) return 0;
-    }
-    return left[1] - right[1];
-  }).map(function(obj) {
-    return obj[2];
-  });
-}
-
 var PreProcessor = {
   process: function(ast) {
     var statements = ast.statements
@@ -176,9 +160,16 @@ var PreProcessor = {
    * https://github.com/wycats/handlebars.js/issues/767
    */
   applySubExpressionHack: function(node) {
-    node.hash.pairs = sortBy(node.hash.pairs, function(pair) {
-      var type = pair[1].type;
-      return type === "sexpr" ? 0 : 1;
+    node.hash.pairs = node.hash.pairs.sort(function(a,b) {
+      if (a[1].type === b[1].type) {
+        return 0
+      }
+      else if (a[1].type === 'sexpr') {
+        return -1;
+      }
+      else if (b[1].type === 'sexpr') {
+        return 1;
+      }
     });
     var pairs = node.hash.pairs;
     if (pairs.length > 1 && pairs[1][1].type === "sexpr")

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grunt-contrib-clean": "~1.0.0",
     "grunt-contrib-copy": "~1.0.0",
     "gruntify-eslint": "~3.1.0",
-    "handlebars": ">=1.3 <3",
+    "handlebars": "~1.3.0",
     "i18nliner": "~0.2.0",
     "jsdom": "~8.5.0",
     "matchdep": "~1.0.1",


### PR DESCRIPTION
the workaround for wycats/handlebars.js/issues/748 employed a sorting
routine that was not commutative and with the v8 upgrade in node11, the
order of the arguments changed (and is considered an implementation
detail that we're not meant to rely on) and so the routine would yield
surprising results

this patch reimplements that sorting routine to always yield the same
result regardless of the order of the operands, so should work on node <
11 and > 11

test plan: there is already a case for this, so I just added node12 to
           the travis language matrix